### PR TITLE
Adding scheduled_trainer_session attribute to workout_plans table

### DIFF
--- a/app/controllers/workout_plans_controller.rb
+++ b/app/controllers/workout_plans_controller.rb
@@ -7,7 +7,8 @@ class WorkoutPlansController < ApplicationController
       starting_date: date_range[0],
       ending_date: date_range[1],
       trainer_id: current_user.id,
-      client_id: @client.id
+      client_id: @client.id,
+      scheduled_trainer_session: params[:workout_plan][:scheduled_trainer_session]
     )
     authorize @workout_plan
     if @workout_plan.save

--- a/app/javascript/controllers/datepicker_workout_session_controller.js
+++ b/app/javascript/controllers/datepicker_workout_session_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
       enableTime: true,
       dateFormat: "Y-m-d H:i",
       disableMobile: "true",
-      minDate: "today",
+      // minDate: "today",
       time_24hr: true,
       minTime: "7:00",
       maxTime: "21:00",

--- a/app/models/workout_plan.rb
+++ b/app/models/workout_plan.rb
@@ -4,6 +4,7 @@ class WorkoutPlan < ApplicationRecord
   has_many :workout_sessions, dependent: :destroy
 
   validates :starting_date, :ending_date, presence: true
+  validates :scheduled_trainer_session, presence: true
   # validate :starting_date_cannot_be_in_the_past
   # validate :ending_date_cannot_be_in_the_past
   validate :plan_date_cannot_be_reverse

--- a/app/models/workout_plan.rb
+++ b/app/models/workout_plan.rb
@@ -28,4 +28,7 @@ class WorkoutPlan < ApplicationRecord
     end
   end
 
+  def trainer_session_count
+    workout_sessions.where(with_trainer: true).count
+  end
 end

--- a/app/views/clients/_scheduled_trainer_sessions.html.erb
+++ b/app/views/clients/_scheduled_trainer_sessions.html.erb
@@ -1,0 +1,14 @@
+<% if workout_plan.trainer_session_count.zero? %>
+  <small class="mt-1 mb-0 mx-1">0/<%= workout_plan.scheduled_trainer_session %> trainer sessions done</small>
+  <div class="d-flex" style="height: 20px; width: 320px; margin: 0 auto">
+    <div style="width: 100%; background-color: #C9B5B5"></div>
+  </div>
+<% else %>
+  <% completed_percent = ((workout_plan.trainer_session_count.to_f/workout_plan.scheduled_trainer_session.to_f) * 100).ceil %>
+  <small class="mt-1 mb-0 mx-1"> <%= workout_plan.trainer_session_count %>/<%= workout_plan.scheduled_trainer_session %> trainer sessions done</small>
+  <div class="d-flex" style="height: 20px; width: 324px; margin: 0 auto">
+    <div style="width: <%= completed_percent %>%; background-color: #B15965">
+    </div>
+    <div style="width: <%= 100-completed_percent %>%; background-color: #C9B5B5"></div>
+  </div>
+<% end %>

--- a/app/views/clients/_workout_plan_display.html.erb
+++ b/app/views/clients/_workout_plan_display.html.erb
@@ -21,13 +21,18 @@
       <div class="card-body p-0">
         <div class="d-flex justify-content-center align-items-start">
           <div class="plan-info">
-            <h3 class="card-title fw-bold text-dark mt-0 mb-1 fs-4">
+            <h3 class="card-title fw-bold text-dark mt-1 mb-1 fs-4">
               <span class="fs-5">From</span> <%= plan.starting_date %> <span class="fs-5">to</span> <%= plan.ending_date %>
             </h3>
+            <!--Scheduled trainer sessions-->
+            <div class="scheduled-trainer-sessions">
+              <%= render 'clients/scheduled_trainer_sessions', workout_plan: plan %>
+            </div>
             <div class="d-flex justify-content-center">
               <% if plan.workout_sessions.any? %>
                 <button type="button" class="btn btn-outline-warning my-4 rounded-pill px-3 py-0 me-2 fw-bold fs-6" data-action="click->display-toggle#fire">
-                  <i class="fa-solid fa-medal"></i> <%= pluralize(plan.workout_sessions.count, "session") %>
+                  <%# <i class="fa-solid fa-medal"></i> <%= pluralize(plan.workout_sessions.count, "session") %>
+                  <i class="fa-solid fa-medal"></i> All sessions
                 </button>
               <% else %>
                 <h5 class="text-muted my-4 badge rounded-pill px-3 py-0 me-2 border bg-white text-dark fw-normal fs-6 d-flex align-items-center">

--- a/app/views/workout_plans/_workout_plan_form.html.erb
+++ b/app/views/workout_plans/_workout_plan_form.html.erb
@@ -15,6 +15,13 @@
                     label: "Select a date range",
                     input_html: { data: {controller: "datepicker-workout-plan"} } %>
               </div>
+              <div class="col-12 my-0">
+                <%= f.label :scheduled_trainer_session, "Number of trainer sessions", class: "form-label" %>
+                <div class="input-group mb-3">
+                  <%= f.input :scheduled_trainer_session, label: false, input_html: { class: "form-control", placeholder: "6" }, wrapper: false %>
+                  <span class="input-group-text">sessions</span>
+                </div>
+              </div>
               <%= f.hidden_field :client_id, value: client.id %>
               <div class="col-12 text-center pt-1">
                 <%= f.submit "Add Plan",  class: "btn btn-danger px-5" %>

--- a/db/migrate/20250829094549_add_scheduled_trainer_session_to_workout_plans.rb
+++ b/db/migrate/20250829094549_add_scheduled_trainer_session_to_workout_plans.rb
@@ -1,0 +1,5 @@
+class AddScheduledTrainerSessionToWorkoutPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :workout_plans, :scheduled_trainer_session, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_26_125027) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_29_094549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -254,6 +254,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_26_125027) do
     t.bigint "client_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "scheduled_trainer_session"
     t.index ["client_id"], name: "index_workout_plans_on_client_id"
     t.index ["trainer_id"], name: "index_workout_plans_on_trainer_id"
   end


### PR DESCRIPTION
Adding scheduled_trainer_session attribute to workout_plans table.
Adding the logic to display the number of real time with trainer sessions vs scheduled number.
<img width="612" height="707" alt="Screenshot 2025-08-29 at 23 03 35" src="https://github.com/user-attachments/assets/52e05821-a549-4c15-a3c1-e3a8e20321f7" />
