### PR TITLE
Center devise form + decrease "Login/Getting started" button font size on large screen

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,7 +52,7 @@ h2 {
 
 h3 {
   font-family: $headers-font;
-  font-size: clamp(20px, 4vw, 32px);
+  font-size: clamp(20px, 4vw, 28px);
   font-weight: 700;
   line-height: 1.3;
   margin-top: 1.25em;
@@ -61,7 +61,7 @@ h3 {
 
 h4 {
   font-family: $headers-font;
-  font-size: clamp(18px, 3.5vw, 28px);
+  font-size: clamp(24px, 3.5vw, 24px);
   font-weight: 700;
   line-height: 1.35;
   margin-top: 1.25em;
@@ -70,7 +70,7 @@ h4 {
 
 h5 {
   font-family: $headers-font;
-  font-size: clamp(16px, 3vw, 24px);
+  font-size: clamp(16px, 3vw, 20px);
   font-weight: 700;
   line-height: 1.4;
   margin-top: 1em;
@@ -79,7 +79,7 @@ h5 {
 
 h6 {
   font-family: $headers-font;
-  font-size: clamp(20px, 2.5vw, 24px);
+  font-size: clamp(12px, 2.5vw, 16px);
   font-weight: 700;
   line-height: 1.4;
   margin-top: 1em;

--- a/app/assets/stylesheets/components/_landing_page.scss
+++ b/app/assets/stylesheets/components/_landing_page.scss
@@ -27,7 +27,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 2.5em;
+    font-size: 1.75em;
   }
   .landing-page-image {
     height: 100vh;

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,37 +1,39 @@
-<div class="container mt-3 mb-5">
-  <div class="row justify-content-center">
-    <div class="col-lg-6 col-md-8 col-sm-12 px-4">
-      <div class="card border-0 rounded-5 shadow-sm">
-        <div class="card-header rounded-top-5 bg-danger border-0 py-4">
-          <h3 class="text-center text-light mt-0 mb-2 fw-bold">Sign up</h3>
-        </div>
-        <div class="card-body pt-3 pb-4">
-          <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-            <%= f.error_notification %>
-            <div class="form-inputs">
-              <%= f.input :email,
+<div class="d-flex justify-content-center align-items-center" style="height: calc(100vh - 124px); margin: 0">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-6 col-md-8 col-sm-12 px-4">
+        <div class="card border-0 rounded-5 shadow-sm">
+          <div class="card-header rounded-top-5 bg-danger border-0 py-3">
+            <h3 class="text-center text-light mt-0 mb-2 fw-bold">Sign up</h3>
+          </div>
+          <div class="card-body pt-3 pb-4">
+            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+              <%= f.error_notification %>
+              <div class="form-inputs">
+                <%= f.input :email,
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "email", class: "rounded-3"  }%>
-              <%= f.input :password,
+                <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password", class: "rounded-3"  } %>
-              <%= f.input :password_confirmation,
+                <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password", class: "rounded-3"  } %>
-              <%= f.input :is_a_trainer,
+                <%= f.input :is_a_trainer,
                   as: :radio_buttons,
                   label: "What are you ?",
                   collection: [[ 'Trainer', true ], [ 'Client', false ]],
                   input_html: { class: "session-selector" },
                   item_wrapper_class: 'session-item' %>
-            </div>
-            <div class="form-actions col-12 text-center my-4">
-              <%= f.button :submit, "Sign up", class: "btn btn-danger px-5 rounded-5 w-100" %>
-            </div>
-          <% end %>
-          <%= render "devise/shared/links" %>
+              </div>
+              <div class="form-actions col-12 text-center my-4">
+                <%= f.button :submit, "Sign up", class: "btn btn-danger px-5 rounded-5 w-100" %>
+              </div>
+            <% end %>
+            <%= render "devise/shared/links" %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,27 +1,29 @@
-<div class="container mt-3 mb-5">
-  <div class="row justify-content-center">
-    <div class="col-lg-10 col-md-10 col-sm-12 px-4">
-      <div class="card border-0 rounded-5 shadow-sm">
-        <div class="card-header rounded-top-5 bg-danger border-0 py-4">
-          <h3 class="text-center text-light mt-0 mb-2 fw-bold">Log in</h3>
-        </div>
-        <div class="card-body pt-3 pb-4">
-          <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-            <div class="form-inputs">
-              <%= f.input :email,
+<div class="d-flex justify-content-center align-items-center" style="height: calc(100vh - 124px); margin: 0">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-6 col-md-8 col-sm-12 px-4">
+        <div class="card border-0 rounded-5 shadow-sm">
+          <div class="card-header rounded-top-5 bg-danger border-0 py-3">
+            <h3 class="text-center text-light mt-0 mb-2 fw-bold">Log in</h3>
+          </div>
+          <div class="card-body pt-3 pb-4">
+            <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+              <div class="form-inputs">
+                <%= f.input :email,
                 required: false,
                 autofocus: true,
                 input_html: { autocomplete: "email", class: "rounded-3" } %>
-              <%= f.input :password,
+                <%= f.input :password,
                 required: false,
                 input_html: { autocomplete: "current-password", class: "rounded-3" } %>
-              <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-            </div>
-            <div class="form-actions col-12 text-center my-4">
-              <%= f.button :submit, "Log in", class: "btn btn-danger px-5 rounded-5 w-100" %>
-            </div>
-          <% end %>
-          <%= render "devise/shared/links" %>
+                <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+              </div>
+              <div class="form-actions col-12 text-center my-4">
+                <%= f.button :submit, "Log in", class: "btn btn-danger px-5 rounded-5 w-100" %>
+              </div>
+            <% end %>
+            <%= render "devise/shared/links" %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -7,7 +7,7 @@
       <div class="col-12 col-md-6 col-lg-4">
         <div class="card h-100 my-3 shadow pt-4 bg-body rounded-5" data-controller="display-toggle">
           <div class="exercise-name text-center">
-            <h6 class="mt-0 mx-2"><%= exercise.name %></h6>
+            <h4 class="mt-0 mx-2"><%= exercise.name %></h4>
           </div>
           <div class="exercise-image text-center mx-3" style="background-color: #f8f9fa;">
             <%= cl_image_tag(exercise.photo.key,


### PR DESCRIPTION
Make login form and signup form to position at the center of the page minus-ing the height of footer navbar. Decreased the font size inside button on landing page (Login/Getting started) from 2.5em to 1.75em as it was too big on Mac screen.


<img width="1470" height="803" alt="Screenshot 2025-09-15 at 23 43 21" src="https://github.com/user-attachments/assets/04dc771a-6b02-443f-b852-ca0dc6bda4a5" />
<img width="1467" height="795" alt="Screenshot 2025-09-15 at 23 43 39" src="https://github.com/user-attachments/assets/44d8a87f-8c50-4863-9d22-356f838b6140" />
<img width="1470" height="804" alt="Screenshot 2025-09-15 at 23 43 50" src="https://github.com/user-attachments/assets/35a5950d-0f5d-4585-b164-95aade61b3e4" />
